### PR TITLE
Allow unescaped `{` as literal when not after atom

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -622,6 +622,13 @@ mod tests {
     }
 
     #[test]
+    fn group_repeat() {
+        assert_eq!(p("(a){2}"), Expr::Repeat{
+            child: Box::new(Expr::Group(Box::new(make_literal("a")))), lo: 2, hi: 2, greedy: true
+        });
+    }
+
+    #[test]
     fn repeat() {
         assert_eq!(p("a{2,42}"), Expr::Repeat{ child: Box::new(make_literal("a")),
             lo: 2, hi: 42, greedy: true });

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -200,7 +200,7 @@ impl<'a> Parser<'a> {
             )),
             b'(' => self.parse_group(ix, depth),
             b'\\' => self.parse_escape(ix),
-            b'+' | b'*' | b'?' | b'|' | b')' | b'{' =>
+            b'+' | b'*' | b'?' | b'|' | b')' =>
                 Ok((ix, Expr::Empty)),
             b'[' => self.parse_class(ix),
             b'#' | b' ' | b'\r' | b'\n' | b'\t'
@@ -552,6 +552,20 @@ mod tests {
     fn literal_special() {
         assert_eq!(p("}"), make_literal("}"));
         assert_eq!(p("]"), make_literal("]"));
+    }
+
+    #[test]
+    fn literal_unescaped_opening_curly() {
+        assert_eq!(p("{"), make_literal("{"));
+        assert_eq!(p("({)"), Expr::Group(Box::new(
+            make_literal("{"),
+        )));
+        assert_eq!(p("a|{"), Expr::Alt(vec![
+            make_literal("a"),
+            make_literal("{"),
+        ]));
+        assert_eq!(p("{{2}"), Expr::Repeat{ child: Box::new(make_literal("{")),
+            lo: 2, hi: 2, greedy: true });
     }
 
     #[test]


### PR DESCRIPTION
This is now more consistent with Oniguruma and PCRE 2:

http://www.pcre.org/current/doc/html/pcre2pattern.html#SEC17

> An opening curly bracket that appears in a position where a quantifier
> is not allowed, or one that does not match the syntax of a quantifier,
> is taken as a literal character. For example, {,6} is not a
> quantifier, but a literal string of four characters.

(As discussed in https://github.com/google/fancy-regex/pull/6)