### PR TITLE
Add support for escapes for control characters

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -240,7 +240,7 @@ impl<'a> Parser<'a> {
             return Err(Error::InvalidBackref)
         } else if b == b'A' || b == b'z' || b == b'b' || b == b'B' {
             size = 0;
-        } else if (b | 32) == b'd' || (b | 32) == b's' || (b | 32) == b'w' {
+        } else if (b | 32) == b'd' || (b | 32) == b's' || (b | 32) == b'w' || b == b'b' || b == b'f' || b == b't' || b == b'n' || b == b'r' || b == b'v' {
             // size = 1
         } else if (b | 32) == b'h' {
             let s = if b == b'h' {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -240,8 +240,12 @@ impl<'a> Parser<'a> {
             return Err(Error::InvalidBackref)
         } else if b == b'A' || b == b'z' || b == b'b' || b == b'B' {
             size = 0;
-        } else if (b | 32) == b'd' || (b | 32) == b's' || (b | 32) == b'w' || b == b'b' || b == b'f' || b == b't' || b == b'n' || b == b'r' || b == b'v' {
+        } else if (b | 32) == b'd' || (b | 32) == b's' || (b | 32) == b'w' ||
+            b == b'a' || b == b'f' || b == b'n' || b == b'r' || b == b't' || b == b'v' {
             // size = 1
+        } else if b == b'e' {
+            let inner = String::from(r"\x1B");
+            return Ok((end, Expr::Delegate { inner: inner, size: size }));
         } else if (b | 32) == b'h' {
             let s = if b == b'h' {
                 "[0-9A-Fa-f]"
@@ -789,6 +793,6 @@ mod tests {
     fn invalid_backref() {
         // only syntactic tests; see similar test in analyze module
         fail(".\\12345678");  // unreasonably large number
-        fail(".\\a");  // not decimal
+        fail(".\\c");  // not decimal
     }
 }

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -1,0 +1,27 @@
+extern crate fancy_regex;
+
+use fancy_regex::Regex;
+
+
+#[test]
+fn control_character_escapes() {
+    assert_matches(r"\a", "\x07");
+    assert_matches(r"\e", "\x1B");
+    assert_matches(r"\f", "\x0C");
+    assert_matches(r"\n", "\x0A");
+    assert_matches(r"\r", "\x0D");
+    assert_matches(r"\t", "\x09");
+    assert_matches(r"\v", "\x0B");
+}
+
+
+fn assert_matches(re: &str, text: &str) {
+    let parse_result = Regex::new(re);
+    assert!(parse_result.is_ok(),
+            "Expected regex '{}' to be compiled successfully, got {:?}", re, parse_result.err());
+
+    let regex = parse_result.unwrap();
+    let match_result = regex.is_match(text);
+    assert!(match_result.is_ok(), "Expected match to succeed, but was {:?}", match_result);
+    assert_eq!(match_result.ok(), Some(true), "Expected regex '{}' to match text '{}'", re, text);
+}


### PR DESCRIPTION
Supports the same set as Oniguruma, see here: https://github.com/kkos/oniguruma/blob/master/doc/RE#L14

I thought this was a good time to introduce tests that use actual matching, as it also verifies that delegation to the regex crate works correctly.

(Cherry-picked @trishume's change with his permission.)