### PR TITLE
Handle fancy escapes in character classes

### DIFF
--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -14,6 +14,25 @@ fn control_character_escapes() {
     assert_matches(r"\v", "\x0B");
 }
 
+#[test]
+fn character_class_escapes() {
+    assert_matches(r"[\[]", "[");
+    assert_matches(r"[\^]", "^");
+
+    // The regex crate would reject the following because it's not necessary to escape them.
+    // Other engines allow to escape any non-alphanumeric character.
+    assert_matches(r"[\<]", "<");
+    assert_matches(r"[\>]", ">");
+    assert_matches(r"[\.]", ".");
+
+    // Character class escape
+    assert_matches(r"[\d]", "1");
+
+    // Control characters
+    assert_matches(r"[\e]", "\x1B");
+    assert_matches(r"[\n]", "\x0A");
+}
+
 
 fn assert_matches(re: &str, text: &str) {
     let parse_result = Regex::new(re);


### PR DESCRIPTION
The code used to delegate parsing of escapes in character classes to the
regex crate. That meant that things that work outside of character
classes such as `\<` or `\e` would not work inside them.

To fix this, change it to parse the escapes ourselves and then map the
result.