### PR TITLE
Update regex to get character class nesting & intersections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,6 @@ description = "An implementation of regexes, supporting a relatively rich set of
 repository = "https://github.com/google/fancy-regex"
 
 [dependencies]
-regex = "0.2.1"
+regex = "0.2.2"
 bit-set = "0.4"
 memchr = "1.0.1"

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -5,36 +5,61 @@ use fancy_regex::Regex;
 
 #[test]
 fn control_character_escapes() {
-    assert_matches(r"\a", "\x07");
-    assert_matches(r"\e", "\x1B");
-    assert_matches(r"\f", "\x0C");
-    assert_matches(r"\n", "\x0A");
-    assert_matches(r"\r", "\x0D");
-    assert_matches(r"\t", "\x09");
-    assert_matches(r"\v", "\x0B");
+    assert_match(r"\a", "\x07");
+    assert_match(r"\e", "\x1B");
+    assert_match(r"\f", "\x0C");
+    assert_match(r"\n", "\x0A");
+    assert_match(r"\r", "\x0D");
+    assert_match(r"\t", "\x09");
+    assert_match(r"\v", "\x0B");
 }
 
 #[test]
 fn character_class_escapes() {
-    assert_matches(r"[\[]", "[");
-    assert_matches(r"[\^]", "^");
+    assert_match(r"[\[]", "[");
+    assert_match(r"[\^]", "^");
 
     // The regex crate would reject the following because it's not necessary to escape them.
     // Other engines allow to escape any non-alphanumeric character.
-    assert_matches(r"[\<]", "<");
-    assert_matches(r"[\>]", ">");
-    assert_matches(r"[\.]", ".");
+    assert_match(r"[\<]", "<");
+    assert_match(r"[\>]", ">");
+    assert_match(r"[\.]", ".");
 
     // Character class escape
-    assert_matches(r"[\d]", "1");
+    assert_match(r"[\d]", "1");
 
     // Control characters
-    assert_matches(r"[\e]", "\x1B");
-    assert_matches(r"[\n]", "\x0A");
+    assert_match(r"[\e]", "\x1B");
+    assert_match(r"[\n]", "\x0A");
+}
+
+#[test]
+fn character_class_nested() {
+    assert_match(r"[[a][bc]]", "c");
+    assert_match(r"[a[^b]]", "c");
+}
+
+#[test]
+fn character_class_intersection() {
+    assert_match(r"[\w&&a-c]", "c");
+    assert_no_match(r"[\w&&a-c]", "d");
+
+    assert_match(r"[[0-9]&&[^4]]", "1");
+    assert_no_match(r"[[0-9]&&[^4]]", "4");
 }
 
 
-fn assert_matches(re: &str, text: &str) {
+fn assert_match(re: &str, text: &str) {
+    let result = match_text(re, text);
+    assert_eq!(result, true, "Expected regex '{}' to match text '{}'", re, text);
+}
+
+fn assert_no_match(re: &str, text: &str) {
+    let result = match_text(re, text);
+    assert_eq!(result, false, "Expected regex '{}' to not match text '{}'", re, text);
+}
+
+fn match_text(re: &str, text: &str) -> bool {
     let parse_result = Regex::new(re);
     assert!(parse_result.is_ok(),
             "Expected regex '{}' to be compiled successfully, got {:?}", re, parse_result.err());
@@ -42,5 +67,5 @@ fn assert_matches(re: &str, text: &str) {
     let regex = parse_result.unwrap();
     let match_result = regex.is_match(text);
     assert!(match_result.is_ok(), "Expected match to succeed, but was {:?}", match_result);
-    assert_eq!(match_result.ok(), Some(true), "Expected regex '{}' to match text '{}'", re, text);
+    match_result.unwrap()
 }


### PR DESCRIPTION
See release notes:

https://github.com/rust-lang/regex/releases/tag/0.2.2