### PR TITLE
Don't ignore space in character classes

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -335,7 +335,6 @@ impl<'a> Parser<'a> {
         let mut nest = 1;
         inner.push('[');
         loop {
-            ix = self.optional_whitespace(ix);
             if ix == self.re.len() {
                 return Err(Error::InvalidClass);
             }
@@ -782,10 +781,10 @@ mod tests {
         assert_eq!(p("(?x: a { 2 , 3 } ? )"), p("a{2,3}?"));
         assert_eq!(p("(?x: ( ? i : . ) )"), p("(?i:.)"));
         assert_eq!(p("(?x: ( ?= a ) )"), p("(?=a)"));
-        assert_eq!(p("(?x: [ ^ a - z ] )"), p("[^a-z]"));
-        assert_eq!(p("(?x: [ : a s c i i : ] )"), p("[:ascii:]"));
-        assert_eq!(p("(?x: [ \\] ] )"), p("[\\]]"));
-        assert_eq!(p("(?x: [ \\] \\\\] )"), p("[\\]\\\\]"));
+        assert_eq!(p("(?x: [ ] )"), p("[ ]"));
+        assert_eq!(p("(?x: [ ^] )"), p("[ ^]"));
+        assert_eq!(p("(?x: [a - z] )"), p("[a - z]"));
+        assert_eq!(p("(?x: [ \\] \\\\] )"), p("[ \\] \\\\]"));
         assert_eq!(p("(?x: a (?-x:#) b )"), p("a#b"));
     }
 


### PR DESCRIPTION
In both Oniguruma and PCRE, `(?x:[ ])` is equivalent to `[ ]` and
matches a literal space character.

See PCRE2 docs mention that comments can not be part of character classes [here](http://www.pcre.org/current/doc/html/pcre2pattern.html#SEC22):

> In both cases, the start of the comment must not be in a character class

It doesn't explicitly mention whitespace, but experimenting with the implementation shows that `(?x:[ ])` matches a space.