### PR TITLE
Allow part of alternation to be empty

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -390,7 +390,7 @@ impl Expr {
 
     pub fn to_str(&self, buf: &mut String, precedence: u8) {
         match *self {
-            Expr::Empty => (),
+            Expr::Empty => buf.push_str(".{0}"),
             Expr::Any { newline } => buf.push_str(
                 if newline { "(?s:.)" } else { "." }
             ),

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -48,6 +48,13 @@ fn character_class_intersection() {
     assert_no_match(r"[[0-9]&&[^4]]", "4");
 }
 
+#[test]
+fn alternation_with_empty_arm() {
+    assert_match(r"^(a|)$", "a");
+    assert_match(r"^(a|)$", "");
+    assert_no_match(r"^(a|)$", "b");
+}
+
 
 fn assert_match(re: &str, text: &str) {
     let result = match_text(re, text);


### PR DESCRIPTION
`(a|)` is valid in both Oniguruma and PCRE 2. Rust's regex rejects it.
This makes fancy-regex support it as well.

Quote from [PCRE docs](http://www.pcre.org/current/doc/html/pcre2pattern.html#SEC12):

> Any number of alternatives may appear, and an empty alternative is permitted (matching the empty string).