### PR TITLE
Fix anchoring of delegate regular expressions

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,8 @@
+use fancy_regex::Regex;
+
+pub fn regex(re: &str) -> Regex {
+    let parse_result = Regex::new(re);
+    assert!(parse_result.is_ok(),
+            "Expected regex '{}' to be compiled successfully, got {:?}", re, parse_result.err());
+    parse_result.unwrap()
+}

--- a/tests/finding.rs
+++ b/tests/finding.rs
@@ -1,0 +1,24 @@
+extern crate fancy_regex;
+
+mod common;
+
+#[test]
+fn lookahead_anchoring() {
+    assert_eq!(find(r"(?=x|a)", "a"), Some((0, 0)));
+    assert_eq!(find(r"(?=x|a)", "bbba"), Some((3, 3)));
+}
+
+#[test]
+fn lookbehind_anchoring() {
+    assert_eq!(find(r"(?<=x|a)", "a"), Some((1, 1)));
+    assert_eq!(find(r"(?<=x|a)", "ba"), Some((2, 2)));
+    assert_eq!(find(r"(?<=^a)", "a"), Some((1, 1)));
+    assert_eq!(find(r"(?<=^a)", "ba"), None);
+}
+
+fn find(re: &str, text: &str) -> Option<(usize, usize)> {
+    let regex = common::regex(re);
+    let result = regex.find(text);
+    assert!(result.is_ok(), "Expected find to succeed, but was {:?}", result);
+    result.unwrap()
+}

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -1,7 +1,6 @@
 extern crate fancy_regex;
 
-use fancy_regex::Regex;
-
+mod common;
 
 #[test]
 fn control_character_escapes() {
@@ -67,12 +66,8 @@ fn assert_no_match(re: &str, text: &str) {
 }
 
 fn match_text(re: &str, text: &str) -> bool {
-    let parse_result = Regex::new(re);
-    assert!(parse_result.is_ok(),
-            "Expected regex '{}' to be compiled successfully, got {:?}", re, parse_result.err());
-
-    let regex = parse_result.unwrap();
-    let match_result = regex.is_match(text);
-    assert!(match_result.is_ok(), "Expected match to succeed, but was {:?}", match_result);
-    match_result.unwrap()
+    let regex = common::regex(re);
+    let result = regex.is_match(text);
+    assert!(result.is_ok(), "Expected match to succeed, but was {:?}", result);
+    result.unwrap()
 }


### PR DESCRIPTION
Before, e.g. a lookahead like `(?=x|a)` would be wrong. The delegate RE
for the `x|a` part inside was compiled as `^x|a`. This means only the
`x` was anchored, but not `a`.

Fix it by adding a non-capturing group so that the delegate is
`^(?:x|a)`, which results in correct anchoring in this case (and
possibly others).