### PR TITLE
Remove unused memchr crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,3 @@ repository = "https://github.com/google/fancy-regex"
 [dependencies]
 regex = "0.2.2"
 bit-set = "0.4"
-memchr = "1.0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,6 @@
 
 extern crate regex;
 extern crate bit_set;
-extern crate memchr;
 
 use std::fmt;
 use std::usize;


### PR DESCRIPTION
It causes a warning on nightly.