### PR TITLE
Change result of analysis to a tree of Info structs

### DIFF
--- a/examples/toy.rs
+++ b/examples/toy.rs
@@ -23,7 +23,7 @@
 extern crate fancy_regex;
 
 use fancy_regex::*;
-use fancy_regex::analyze::Analysis;
+use fancy_regex::analyze::analyze;
 use fancy_regex::compile::compile;
 use std::env;
 use std::str::FromStr;
@@ -34,13 +34,13 @@ fn main() {
         if cmd == "parse" {
             if let Some(re) = args.next() {
                 let e = Expr::parse(&re);
-                println!("{:?}", e);
+                println!("{:#?}", e);
             }
         } else if cmd == "analyze" {
             if let Some(re) = args.next() {
                 let (e, backrefs) = Expr::parse(&re).unwrap();
-                let a = Analysis::analyze(&e, &backrefs);
-                println!("{:?}", a);
+                let a = analyze(&e, &backrefs);
+                println!("{:#?}", a);
             }
         } else if cmd == "compile" {
             if let Some(re) = args.next() {
@@ -73,7 +73,7 @@ fn main() {
         } else if cmd == "trace" {
             if let Some(re) = args.next() {
                 let (e, backrefs) = Expr::parse(&re).unwrap();
-                let a = Analysis::analyze(&e, &backrefs).unwrap();
+                let a = analyze(&e, &backrefs).unwrap();
                 let p = compile(&a).unwrap();
                 if let Some(s) = args.next() {
                     vm::run(&p, &s, 0, vm::OPTION_TRACE).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ pub mod compile;
 pub mod vm;
 
 use parse::Parser;
-use analyze::Analysis;
+use analyze::analyze;
 use compile::compile;
 use vm::Prog;
 
@@ -129,9 +129,9 @@ impl Regex {
             ))
         ]);
 
-        let a = Analysis::analyze(&e, &backrefs)?;
+        let info = analyze(&e, &backrefs)?;
 
-        let inner_info = &a.infos[4];  // references inner expr
+        let inner_info = &info.children[1].children[0];  // references inner expr
         if !inner_info.hard {
             // easy case, wrap regex
 
@@ -163,10 +163,10 @@ impl Regex {
             });
         }
 
-        let p = try!(compile(&a));
+        let p = try!(compile(&info));
         Ok(Regex::Impl {
             prog: p,
-            n_groups: a.n_groups(),
+            n_groups: info.end_group,
             original: re.to_string(),
         })
     }


### PR DESCRIPTION
This makes the code in the Analyzer and Compiler easier to follow.

I'm working on making regexes like `(?<=$|.)` work, and while this change is not required for that, it makes it simpler to implement.