### PR TITLE
Support look-behind with variable sized alternative

### DIFF
--- a/examples/toy.rs
+++ b/examples/toy.rs
@@ -23,7 +23,7 @@
 extern crate fancy_regex;
 
 use fancy_regex::*;
-use fancy_regex::analyze::Analysis;
+use fancy_regex::analyze::analyze;
 use fancy_regex::compile::compile;
 use std::env;
 use std::str::FromStr;
@@ -34,13 +34,13 @@ fn main() {
         if cmd == "parse" {
             if let Some(re) = args.next() {
                 let e = Expr::parse(&re);
-                println!("{:?}", e);
+                println!("{:#?}", e);
             }
         } else if cmd == "analyze" {
             if let Some(re) = args.next() {
                 let (e, backrefs) = Expr::parse(&re).unwrap();
-                let a = Analysis::analyze(&e, &backrefs);
-                println!("{:?}", a);
+                let a = analyze(&e, &backrefs);
+                println!("{:#?}", a);
             }
         } else if cmd == "compile" {
             if let Some(re) = args.next() {
@@ -73,7 +73,7 @@ fn main() {
         } else if cmd == "trace" {
             if let Some(re) = args.next() {
                 let (e, backrefs) = Expr::parse(&re).unwrap();
-                let a = Analysis::analyze(&e, &backrefs).unwrap();
+                let a = analyze(&e, &backrefs).unwrap();
                 let p = compile(&a).unwrap();
                 if let Some(s) = args.next() {
                     vm::run(&p, &s, 0, vm::OPTION_TRACE).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ pub mod compile;
 pub mod vm;
 
 use parse::Parser;
-use analyze::Analysis;
+use analyze::analyze;
 use compile::compile;
 use vm::Prog;
 
@@ -129,9 +129,9 @@ impl Regex {
             ))
         ]);
 
-        let a = Analysis::analyze(&e, &backrefs)?;
+        let info = analyze(&e, &backrefs)?;
 
-        let inner_info = &a.infos[4];  // references inner expr
+        let inner_info = &info.children[1].children[0];  // references inner expr
         if !inner_info.hard {
             // easy case, wrap regex
 
@@ -163,10 +163,10 @@ impl Regex {
             });
         }
 
-        let p = try!(compile(&a));
+        let p = try!(compile(&info));
         Ok(Regex::Impl {
             prog: p,
-            n_groups: a.n_groups(),
+            n_groups: info.end_group,
             original: re.to_string(),
         })
     }

--- a/tests/finding.rs
+++ b/tests/finding.rs
@@ -2,6 +2,8 @@ extern crate fancy_regex;
 
 mod common;
 
+use fancy_regex::Regex;
+
 #[test]
 fn lookahead_anchoring() {
     assert_eq!(find(r"(?=x|a)", "a"), Some((0, 0)));
@@ -15,6 +17,33 @@ fn lookbehind_anchoring() {
     assert_eq!(find(r"(?<=^a)", "a"), Some((1, 1)));
     assert_eq!(find(r"(?<=^a)", "ba"), None);
 }
+
+#[test]
+fn lookbehind_variable_sized_alt() {
+    assert_eq!(find(r"(?<=a|bc)", "xxa"), Some((3, 3)));
+    assert_eq!(find(r"(?<=a|bc)", "xxbc"), Some((4, 4)));
+    assert_eq!(find(r"(?<=a|bc)", "xx"), None);
+    assert_eq!(find(r"(?<=a|bc)", "xxb"), None);
+    assert_eq!(find(r"(?<=a|bc)", "xxc"), None);
+
+    assert!(Regex::new(r"(?<=a(?:b|cd))").is_err());
+    assert!(Regex::new(r"(?<=a+b+))").is_err());
+}
+
+#[test]
+fn negative_lookbehind_variable_sized_alt() {
+    assert_eq!(find(r"(?<!a|bc)x", "axx"), Some((2, 3)));
+    assert_eq!(find(r"(?<!a|bc)x", "bcxx"), Some((3, 4)));
+    assert_eq!(find(r"(?<!a|bc)x", "x"), Some((0, 1)));
+    assert_eq!(find(r"(?<!a|bc)x", "bx"), Some((1, 2)));
+    assert_eq!(find(r"(?<!a|bc)x", "cx"), Some((1, 2)));
+    assert_eq!(find(r"(?<!a|bc)x", "ax"), None);
+    assert_eq!(find(r"(?<!a|bc)x", "bcx"), None);
+
+    assert!(Regex::new(r"(?<!a(?:b|cd))").is_err());
+    assert!(Regex::new(r"(?<!a+b+)").is_err());
+}
+
 
 fn find(re: &str, text: &str) -> Option<(usize, usize)> {
     let regex = common::regex(re);


### PR DESCRIPTION
The sub expression of a positive or negative look-behind is required to
be constant size for the VM.

But we can support a positive look-behind with an alternative such as
`(?<=a|bb)` by compiling it as `(?<=a)|(?<=bb)`.

A negative look-behind like `(?<!a|bb)` becomes `(?<!a)(?<!bb)`.

(Note: This PR depends on #24, it includes that commit. So either merge the other PR first or look at the second commit for reviewing.)