### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,6 @@ language: rust
 dist: trusty
 sudo: false
 
-rust:
-  - stable
-  - beta
-  - nightly
-
 matrix:
   include:
     - rust: stable
@@ -15,6 +10,8 @@ matrix:
         apt:
           packages:
             - libssl-dev
+    - rust: beta
+    - rust: nightly
   allow_failures:
     - rust: nightly
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
             - libssl-dev
       install:
         # For test coverage. In install step so that it can use cache.
-        - cargo install cargo-tarpaulin
+        - cargo tarpaulin --version || cargo install cargo-tarpaulin
     - rust: beta
     - rust: nightly
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+---
+language: rust
+dist: trusty
+sudo: false
+
+rust:
+  - stable
+  - beta
+  - nightly
+
+matrix:
+  include:
+    - rust: stable
+      addons:
+        apt:
+          packages:
+            - libssl-dev
+  allow_failures:
+    - rust: nightly
+
+cache:
+  cargo: true
+  apt: true
+
+script:
+  - cargo build --verbose
+  - cargo test --verbose
+  - 'if [[ "$TRAVIS_RUST_VERSION" = nightly ]]; then cargo bench; fi'
+
+after_success: |
+  if [[ "$TRAVIS_RUST_VERSION" = stable ]]; then
+    # test coverage
+    cargo install cargo-tarpaulin
+    cargo tarpaulin --out Xml
+    bash <(curl -s https://codecov.io/bash)
+  fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,17 @@ matrix:
       addons:
         apt:
           packages:
+            # cargo-tarpaulin needs this
             - libssl-dev
+      install:
+        # For test coverage. In install step so that it can use cache.
+        - cargo install cargo-tarpaulin
     - rust: beta
     - rust: nightly
   allow_failures:
     - rust: nightly
 
-cache:
-  cargo: true
-  apt: true
+cache: cargo
 
 script:
   - cargo build --verbose
@@ -26,8 +28,7 @@ script:
 
 after_success: |
   if [[ "$TRAVIS_RUST_VERSION" = stable ]]; then
-    # test coverage
-    cargo install cargo-tarpaulin
+    # Calculate test coverage
     cargo tarpaulin --out Xml
     bash <(curl -s https://codecov.io/bash)
   fi

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -32,7 +32,7 @@ mod bench {
     use regex::Regex;
 
 	use fancy_regex::Expr;
-    use fancy_regex::analyze::Analysis;
+    use fancy_regex::analyze::analyze;
     use fancy_regex::compile::compile;
     use fancy_regex::vm;
 
@@ -54,7 +54,7 @@ mod bench {
     #[bench]
     fn literal_re_analyze(b: &mut Bencher) {
         let (e, br) = Expr::parse("^\\\\([!-/:-@\\[-`\\{-~aftnrv]|[0-7]{1,3}|x[0-9a-fA-F]{2}|x\\{[0-9a-fA-F]{1,6}\\})").unwrap();
-        b.iter(|| Analysis::analyze(&e, &br));
+        b.iter(|| analyze(&e, &br));
     }
 
     #[bench]
@@ -72,7 +72,7 @@ mod bench {
     #[bench]
     fn run_backtrack(b: &mut Bencher) {
         let (e, br) = Expr::parse("^.*?(([ab]+)\\1b)").unwrap();
-        let a = Analysis::analyze(&e, &br).unwrap();
+        let a = analyze(&e, &br).unwrap();
         let p = compile(&a).unwrap();
         b.iter(|| vm::run(&p, "babab", 0, 0))
     }
@@ -82,7 +82,7 @@ mod bench {
     #[bench]
     fn run_tricky(b: &mut Bencher) {
         let (e, br) = Expr::parse("(a|b|ab)*bc").unwrap();
-        let a = Analysis::analyze(&e, &br).unwrap();
+        let a = analyze(&e, &br).unwrap();
         let p = compile(&a).unwrap();
         let mut s = String::new();
         for _ in 0..28 {


### PR DESCRIPTION
Travis build with:

* Compile and run tests on Rust stable, beta and nightly
* On nightly, the build is allowed to fail (because of bugs in Rust nightly)
* On nightly, also run compile and run benches
* On stable, also run coverage and publish to [codecov](https://codecov.io/), see example output here (it has only run on the branch, so I think that's why the diff output is not yet useful): https://codecov.io/gh/robinst/fancy-regex/tree/2447b0cd03617bb51702ee27a6fc49fb13bdb3f6/src

See the build result here: https://travis-ci.org/robinst/fancy-regex