### PR TITLE
Fix handling of unescaped `]` in character class

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -350,6 +350,19 @@ impl<'a> Parser<'a> {
         let mut class = String::new();
         let mut nest = 1;
         class.push('[');
+
+        // Negated character class
+        if ix < self.re.len() && bytes[ix] == b'^' {
+            class.push('^');
+            ix += 1;
+        }
+
+        // `]` does not have to be escaped after opening `[` or `[^`
+        if ix < self.re.len() && bytes[ix] == b']' {
+            class.push(']');
+            ix += 1;
+        }
+
         loop {
             if ix == self.re.len() {
                 return Err(Error::InvalidClass);

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -30,6 +30,11 @@ fn character_class_escapes() {
     // Control characters
     assert_match(r"[\e]", "\x1B");
     assert_match(r"[\n]", "\x0A");
+
+    // `]` can be unescaped if it's right after `[`
+    assert_match(r"[]]", "]");
+    // `]` can be unescaped even after `[^`
+    assert_match(r"[^]]", "a");
 }
 
 #[test]


### PR DESCRIPTION
`[]]` and `[^]]` are both valid, and are equivalent to `[\]]` and
`[^\]]` respectively.

Quoting from [PCRE2](http://www.pcre.org/current/doc/html/pcre2pattern.html#SEC9):

> If a closing square bracket is required as a member of the class, it
> should be the first data character in the class (after an initial
> circumflex, if present) or escaped with a backslash.