### PR TITLE
Fix left-looking alt if first child is left-looking

### DIFF
--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -111,6 +111,7 @@ impl<'a> Analyzer<'a> {
                 min_size = child_info.min_size;
                 const_size = child_info.const_size;
                 hard = child_info.hard;
+                looks_left = child_info.looks_left;
                 children.push(child_info);
                 for child in &v[1..] {
                     let child_info = self.visit(child)?;

--- a/tests/finding.rs
+++ b/tests/finding.rs
@@ -44,6 +44,12 @@ fn negative_lookbehind_variable_sized_alt() {
     assert!(Regex::new(r"(?<!a+b+)").is_err());
 }
 
+#[test]
+fn lookahead_looks_left() {
+    assert_eq!(find(r"a(?=\b|_)", "a."), Some((0, 1)));
+    assert_eq!(find(r"a(?=_|\b)", "a."), Some((0, 1)));
+}
+
 
 fn find(re: &str, text: &str) -> Option<(usize, usize)> {
     let regex = common::regex(re);


### PR DESCRIPTION
The first assertion in the test case was failing before because
`looks_left` was analyzed to `false` on the `Alt`.