### PR TITLE
Fix lookaround with a concat that contains an alt and another lookaround

### DIFF
--- a/tests/finding.rs
+++ b/tests/finding.rs
@@ -5,13 +5,23 @@ mod common;
 use fancy_regex::Regex;
 
 #[test]
-fn lookahead_anchoring() {
+fn lookahead_grouping_single_expression() {
+    // These would fail if the delegate expression was `^x|a` (if we didn't
+    // group as `^(?:x|a)`).
     assert_eq!(find(r"(?=x|a)", "a"), Some((0, 0)));
     assert_eq!(find(r"(?=x|a)", "bbba"), Some((3, 3)));
 }
 
 #[test]
-fn lookbehind_anchoring() {
+fn lookahead_grouping_multiple_expressions() {
+    // These would fail if the delegate expression was `^ab|Bc` (if we didn't
+    // preserve grouping of `(?:b|B)`).
+    assert_eq!(find(r"(?=(?!x)a(?:b|B)c)", "aBc"), Some((0, 0)));
+    assert_eq!(find(r"(?=(?!x)a(?:b|B)c)", "Bc"), None);
+}
+
+#[test]
+fn lookbehind_grouping_single_expression() {
     assert_eq!(find(r"(?<=x|a)", "a"), Some((1, 1)));
     assert_eq!(find(r"(?<=x|a)", "ba"), Some((2, 2)));
     assert_eq!(find(r"(?<=^a)", "a"), Some((1, 1)));


### PR DESCRIPTION
We did a fix earlier for grouping a single delegate expression, but
turns out a concat of multiple delegate expressions also has problems.

The nested lookaround is necessary to trigger this bug because otherwise
the entire concat is delegated, in which case the grouping is correct.

This was a fun one to track down :). I was really confused that either removing the nested lookaround fixed the problem, or changing the order of the alt branches. Anyway, using the `toy` example with `trace` really helped! (I wonder if we should rename it to something less toy-y like `explain`.)