### PR TITLE
Add "graph" and "trace-inner" commands to toy

### DIFF
--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -30,8 +30,6 @@ use Result;
 
 #[derive(Debug)]
 pub struct Info<'a> {
-    pub expr: &'a Expr,
-    pub children: Vec<Info<'a>>,
     pub start_group: usize,
     pub end_group: usize,
     pub min_size: usize,
@@ -42,6 +40,9 @@ pub struct Info<'a> {
     /// previous character was. E.g. `^` matches if there's no previous
     /// character; `(?m:^)` matches if the previous character was a newline.
     pub looks_left: bool,
+
+    pub expr: &'a Expr,
+    pub children: Vec<Info<'a>>,
 }
 
 impl<'a> Info<'a> {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -65,7 +65,7 @@ pub enum Insn {
 
 #[derive(Debug)]
 pub struct Prog {
-    body: Vec<Insn>,
+    pub body: Vec<Insn>,
     n_saves: usize,
 }
 


### PR DESCRIPTION
The graph command prints a graphviz file to render a VM program to a
nice visual representation. That makes it easier to follow than text
because the possible flows are visible.

Also changed the "trace" command to trace the full program, and make the
old trace "trace-inner". Not sure about the names, but this should
reduce confusion because the full trace can be compared to run/graph.

Example graph for regex ```(?!`(?:[^`]+(?=`)|x)`)```:

<img width="323" alt="screen shot 2018-01-21 at 16 13 08" src="https://user-images.githubusercontent.com/16778/35191085-04b090ca-fec6-11e7-9854-ef87080658b3.png">