### PR TITLE
Remove unnecessary jump instruction for last branch of alt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,5 @@ regex = "0.2.2"
 bit-set = "0.4"
 
 [dev-dependencies]
+matches = "0.1.6"
 quickcheck = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,9 @@ extern crate bit_set;
 
 #[cfg(test)]
 #[macro_use]
+extern crate matches;
+#[cfg(test)]
+#[macro_use]
 extern crate quickcheck;
 
 use std::fmt;


### PR DESCRIPTION
I accidentally introduced the unnecessary jump in PR #25.