### PR TITLE
Fix negative lookaround matching

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -333,7 +333,7 @@ impl Compiler {
         let pc = self.b.pc();
         self.b.add(Insn::Split(pc + 1, usize::MAX));
         self.compile_lookaround_inner(inner, la)?;
-        self.b.add(Insn::DoubleFail);
+        self.b.add(Insn::FailNegativeLookAround);
         let next_pc = self.b.pc();
         self.b.set_split_target(pc, next_pc, true);
         Ok(())

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -49,7 +49,7 @@ pub enum Insn {
     RepeatNg { lo: usize, hi: usize, next: usize, repeat: usize },
     RepeatEpsilonGr { lo: usize, next: usize, repeat: usize, check: usize },
     RepeatEpsilonNg { lo: usize, next: usize, repeat: usize, check: usize },
-    DoubleFail,
+    FailNegativeLookAround,
     GoBack(usize),
     Backref(usize),
     BeginAtomic,
@@ -333,9 +333,22 @@ pub fn run(prog: &Prog, s: &str, pos: usize, options: u32) ->
                         ix = prev_codepoint_ix(s, ix);
                     }
                 }
-                Insn::DoubleFail => {
-                    // negative lookaround
-                    let _ = state.pop();
+                Insn::FailNegativeLookAround => {
+                    // Reaching this instruction means that the body of the
+                    // lookaround matched. Because it's a *negative* lookaround,
+                    // that means the lookaround itself should fail (not match).
+                    // But before, we need to discard all the states that have
+                    // been pushed with the lookaround, because we don't want to
+                    // explore them.
+                    loop {
+                        let (popped_pc, _) = state.pop();
+                        if popped_pc == pc + 1 {
+                            // We've reached the state that would jump us to
+                            // after the lookaround (in case the lookaround
+                            // succeeded). That means we popped enough states.
+                            break;
+                        }
+                    }
                     break 'fail;
                 }
                 Insn::Backref(slot) => {

--- a/tests/finding.rs
+++ b/tests/finding.rs
@@ -60,6 +60,18 @@ fn lookahead_looks_left() {
     assert_eq!(find(r"a(?=_|\b)", "a."), Some((0, 1)));
 }
 
+#[test]
+fn negative_lookahead_fail() {
+    // This was a tricky one. There's a negative lookahead that contains a
+    // "hard" alternative (because of the lookahead). When the VM gets to the
+    // point where the body of the negative lookahead matched, it needs to fail
+    // the negative lookahead match. That means it needs to pop the stack until
+    // before the negative lookahead, and then fail. But how many times it has
+    // to pop is not fixed, it depends on the body/VM state.
+    assert_eq!(find(r"(?!a(?=b)|x)", "ab"), Some((1, 1)));
+    assert_eq!(find(r"(?!`(?:[^`]+(?=`)|x)`)", "`a`"), Some((1, 1)));
+}
+
 
 fn find(re: &str, text: &str) -> Option<(usize, usize)> {
     let regex = common::regex(re);


### PR DESCRIPTION
Finding pattern `(?!a(?=b)|x)` in the text `ab` produced the incorrect
result (0, 0), instead of (1, 1).

The reason for that was that the implementation with the DoubleFail
instruction would only pop 1 state before failing. But in a case like
the above, there is more than 1 state that needs to be popped because of
the alternative.

Here's the program graph (using #40) before this change:

<img width="359" alt="fancy-regex-graph-abx" src="https://user-images.githubusercontent.com/16778/35192016-1cfe6492-fedd-11e7-9418-67318fa0df9e.png">

And the output of `toy trace "(?!a(?=b)|x)" "ab"` (using #39):

```
pos	instruction
0	0 Split(3, 1)
stack after push: [(1, 0, 0)]
0	3 Save(0)
saves: [0, 18446744073709551615, 18446744073709551615]
0	4 Split(5, 14)
stack after push: [(1, 0, 0), (14, 0, 1)]
0	5 Split(6, 11)
stack after push: [(1, 0, 0), (14, 0, 1), (11, 0, 0)]
0	6 Lit("a")
1	7 Save(2)
saves: [0, 18446744073709551615, 1]
1	8 Lit("b")
2	9 Restore(2)
1	10 Jmp(13)
1	13 DoubleFail
stack after pop: [(1, 0, 0), (14, 0, 1)]
fail
stack after pop: [(1, 0, 0)]
0	14 Save(1)
saves: [0, 0, 18446744073709551615]
0	15 End
saves: [0, 0, 18446744073709551615]
```

`Split(5, 14)` is the negative lookahead, `Split(6, 11)` is the alternative.
Now check what happens at `DoubleFail`: There's one pop, which discards
`(11, 0, 0)`. Then there's the fail, and we pop again, and resume at 14.
But 14 is the instruction after the lookahead (in case it succeeded)!

With this change, we pop both 11 and 14 and then fail. Then we resume
instruction `1 Any` as expected. At the end, the correct result (1, 1) is returned.