### PR TITLE
Fix alternations with empty sub-expressions with regex >= 0.2.7

### DIFF
--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -57,6 +57,12 @@ fn character_class_intersection() {
 fn alternation_with_empty_arm() {
     assert_match(r"^(a|)$", "a");
     assert_match(r"^(a|)$", "");
+    assert_match(r"^(|a)$", "a");
+    assert_match(r"^(|a)$", "");
+    assert_match(r"a|", "a");
+    assert_match(r"a|", "");
+    assert_match(r"|a", "a");
+    assert_match(r"|a", "");
     assert_no_match(r"^(a|)$", "b");
 }
 


### PR DESCRIPTION
With regex 0.2.7 and higher, the trick to rewrite `(a|b|)` to `(a|b|.{0})` doesn't work anymore, it fails with this error:

> alternations cannot currently contain empty sub-expressions

So delegate it like this instead: `((?:a|b)?)`