### PR TITLE
Cargo.toml Add [workspace] to fix travis

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,5 @@ bit-set = "0.5"
 [dev-dependencies]
 matches = "0.1.6"
 quickcheck = "0.6"
+
+[workspace]


### PR DESCRIPTION
https://github.com/google/fancy-regex/pull/52 is blocked because,

> the cargo feature `publish-lockfile` requires a nightly version of Cargo, but this is the `stable` channel

This was reported in https://github.com/rust-lang/cargo/issues/6015 and after looking at the project referenced there (https://github.com/xd009642/tarpaulin/blob/master/tests/data/simple_project/Cargo.toml) then I believe the fix is what is in this PR :)